### PR TITLE
A set of minor styles adjustments

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -102,7 +102,7 @@ a:hover {
  * Map link
  */
 .sassdoc__map a {
-  font-weight: bold;
+  font-weight: 500;
   color: #699;
   text-decoration: none;
 }
@@ -123,7 +123,7 @@ a:hover {
  * List item section
  */
 .sassdoc__map-section a {
-  font-weight: bold;
+  font-weight: 500;
   display: block;
   color: #c7254e;
   margin-top: 1em;

--- a/templates/layouts/base.html.swig
+++ b/templates/layouts/base.html.swig
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>SassDoc :: Documentation</title>
   <link rel="stylesheet" href="assets/css/styles.css" />
-  <link rel='stylesheet' href='http://fonts.googleapis.com/css?family=Ubuntu'>
+  <link rel='stylesheet' href='http://fonts.googleapis.com/css?family=Ubuntu:400,500,700'>
   <meta name="viewport" content="width=device-width">
 </head>
 <body>


### PR DESCRIPTION
- Add a bit of padding at the `map-container` bottom
- Include medium, and bold version of the Ubuntu font to prevent forcing "faux-bold" on headings, and all bold set items. Use medium weight on the `map-container` items to slightly lighten the visual effect.
