### PR TITLE
fix: custom config path always leads to default

### DIFF
--- a/bin/sassdoc
+++ b/bin/sassdoc
@@ -13,7 +13,7 @@ if (options['--verbose'] === true) {
   log.enabled = true;
 }
 
-var config = require(options['--config'] ? '../' + options['--config'] : '../view.json');
+var config = require(options['--config'] ? process.cwd() + '/' + options['--config'] : '../view.json');
 
 if (typeof options['<src>'] !== 'undefined' || typeof options['<dest>'] !== 'undefined') {
   api.documentize(options['<src>'], options['<dest>'], config);


### PR DESCRIPTION
The most common use is to call the SassDoc binary from the root of your project, thus specifying path relative to it. So if I have a custom `view.json` file at the root of my project, it will never get used, the default one will be picked.
