### PR TITLE
feat: make sure `documentize` returns a promise

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -10,6 +10,7 @@ exports = module.exports = {
    * @param {String} destination - Destination folder
    * @example
    * documentize('examples/sass', 'examples/dist')
+   * @return {Q.promise}
    */
   documentize: function (source, destination, config) {
     return fs.folder.refresh(destination)


### PR DESCRIPTION
Make the API `documentize` function returns a promise as for `parse` this will be useful for third parties using the API. Let's say a Grunt plugin for instance... :-)
