### PR TITLE
Additional space in cli file breaks --config arg

### DIFF
--- a/bin/sassdoc
+++ b/bin/sassdoc
@@ -11,7 +11,7 @@ Options:
   -h, --help            Bring help.
   --version             Show version.
   -v, --verbose         Run in verbose mode.
-  -c,  --config=<path>  Path to JSON file containing variable to be passed
+  -c, --config=<path>   Path to JSON file containing variable to be passed
                         to the view.
 */
 


### PR DESCRIPTION
Remove an additional space in cli file that prevented the --config arg to be correctly parsed, thus ignoring any custom `view.json` file.
