### PR TITLE
Add a grunt workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,145 @@
+
+module.exports = function (grunt) {
+
+  'use strict';
+
+  // Load all grunt tasks matching the `grunt-*` pattern.
+  require('load-grunt-tasks')(grunt);
+
+  // Time how long tasks take.
+  require('time-grunt')(grunt);
+
+  // Require SassDoc file utils.
+  var sdfs = require('./src/file');
+
+  // Project specific paths.
+  var dirs = {
+    cwd: '.',
+    base: 'examples/dist', // Server base.
+    scss: 'view/scss',
+    css: 'view/assets/css',
+    tpl: 'view/templates',
+    dist: 'examples/dist',
+    src: 'src',
+    test: 'src/annotation/annotations/test'
+  };
+
+  grunt.initConfig({
+
+    // Load package Object.
+    // pkg: grunt.file.readJSON('package.json'),
+
+    dirs: dirs,
+
+    sass: {
+      options: {
+        style: 'compressed'
+      },
+      view: {
+        files: [{
+          expand: true,
+          cwd: '<%= dirs.scss %>',
+          src: ['*.scss'],
+          dest: '<%= dirs.css %>',
+          ext: '.css'
+        }]
+      }
+    },
+
+    mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec'
+        },
+        src: ['<%= dirs.test %>/*.js']
+      }
+    },
+
+    jshint: {
+      options: {
+        jshintrc: '.jshintrc'
+      },
+      all: [
+        'Gruntfile.js',
+        '<%= dirs.src %>/**/*.js'
+      ]
+    },
+
+    watch: {
+      scss: {
+        files: ['<%= dirs.scss %>/**/*.scss'],
+        tasks: ['sass:view']
+      },
+      tpl: {
+        files: ['<%= dirs.tpl %>/**/*.swig'],
+        tasks: ['compile']
+      }
+    },
+
+    browserSync: {
+      dist: {
+        bsFiles: {
+          src: [
+            '<%= dirs.dist %>/*.html',
+            '<%= dirs.dist %>/**/*.css',
+            '<%= dirs.dist %>/**/*.js'
+          ]
+        },
+        options: {
+          watchTask: true,
+          server: {
+            baseDir: '<%= dirs.base %>'
+          }
+        }
+      }
+    }
+
+  });
+
+
+  // A custom task to compile through SassDoc cli.
+  grunt.registerTask('compile', 'Generates documentation', function () {
+    var done = this.async();
+
+    grunt.util.spawn({
+      cmd: 'bin/sassdoc',
+      args: ['examples/stylesheets', 'examples/dist', '--verbose']
+    },
+    function (error, result) {
+      if (error) {
+        grunt.log.error(error);
+      }
+      if (result) {
+        grunt.log.writeln(result);
+      }
+
+      done();
+    });
+  });
+
+  // Make the Sass dist action faster
+  // by not requiring a full `compile`.
+  grunt.event.on('watch', function (action, filepath, target) {
+    if (target === 'scss' && action === 'changed') {
+      sdfs.dumpAssets(dirs.dist);
+    }
+  });
+
+  // While working on the view.
+  grunt.registerTask('dist', [
+    'browserSync:dist',
+    'watch'
+  ]);
+
+  // Before push and for travis.
+  grunt.registerTask('test', [
+    'jshint:all',
+    'mochaTest'
+  ]);
+
+  // All together.
+  grunt.registerTask('default', [
+    // @todo: define needs.
+  ]);
+
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "url": "https://github.com/HugoGiraudel/SassDoc/issues"
   },
   "main": "src/api.js",
+  "bin": {
+    "sassdoc": "./bin/sassdoc"
+  },
   "dependencies": {
     "swig": "~1.3.2",
     "q": "^1.0.1",
@@ -36,10 +39,18 @@
     "ncp": "^0.5.1",
     "scsscommentparser": "0.0.17"
   },
-  "bin": {
-    "sassdoc": "./bin/sassdoc"
-  },
   "devDependencies": {
-    "assert": "^1.1.1"
+    "assert": "^1.1.1",
+    "grunt": "^0.4.5",
+    "grunt-browser-sync": "^1.1.2",
+    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-sass": "^0.7.3",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-mocha-test": "^0.11.0",
+    "load-grunt-tasks": "^0.6.0",
+    "time-grunt": "^0.3.2"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
Grunt workflow groundwork.
- A task to work on the view: (scss, swig, compile, browser syncing, ...) `$ grunt dist` 
- A task to run js tests before pushing or to be used by travis (jshint, mocha) `$ grunt test` 

this refs #55 
