### PR TITLE
Remove trailing space in Swig item template to enhance syntax highlighting

### DIFF
--- a/view/templates/includes/items/item.html.swig
+++ b/view/templates/includes/items/item.html.swig
@@ -20,7 +20,7 @@
     {% set parameters_string = parameters_string + ', ' + value %}
   {% endif %}
 {% endfor %}
-<pre class="item__code"><code class="language-scss">@{{ item.context.type }} {{ item.context.name }} ({{ parameters_string }}) { ... }</code></pre>
+<pre class="item__code"><code class="language-scss">@{{ item.context.type }} {{ item.context.name }}({{ parameters_string }}) { ... }</code></pre>
 
 {% if not item.alias %}
 


### PR DESCRIPTION
The space between the name of a `@function` / `@mixin` and the opening parentheses causes Prism to choke / not recognize and highlight everything correctly.

**Before:**

``` scss
@mixin name () { ... }
@function name () { ... }
```

This caused Prism to not highlight everything correctly like so:

``` html
<code class=" language-scss" data-language="scss">
  <span class="token keyword">@mixin</span> text-highlighted ()<span class="token selector"> </span><span class="token punctuation">{</span> ... <span class="token punctuation">}</span>
</code>
```

**After:**

``` scss
@mixin name() { ... }
@function name() { ... }
```

Which results in correctly formatted markup via prism:

``` html
<code class=" language-scss" data-language="scss">
  <span class="token keyword">@mixin</span> <span class="token function">text-highlighted</span>()<span class="token selector"> </span><span class="token punctuation">{</span> ... <span class="token punctuation">}</span>
</code>
```
