### PR TITLE
Add support for external requires Fix #61

### DIFF
--- a/examples/dist/index.html
+++ b/examples/dist/index.html
@@ -813,7 +813,7 @@
   
   <h3 class="item__sub-heading">Description</h3>
   
-  <div class="item__description"><p>Helper to manage <code>z-index</code>. <br>Tries to fetch the z-index mapped to <code>$layer</code> in <code>$z-indexes</code> map.<br>If found, returns it, else returns <code>null</code>.</p></div>
+  <div class="item__description"><p>Helper to manage <code>z-index</code>.<br>Tries to fetch the z-index mapped to <code>$layer</code> in <code>$z-indexes</code> map.<br>If found, returns it, else returns <code>null</code>.</p></div>
 
 
   <h3 class="item__sub-heading">Parameters</h3>
@@ -888,7 +888,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#variable-z-indexes"><code>z-indexes</code></a></li>
+    
+      <li><a href="#variable-z-indexes"><code>z-indexes</code></a>  Z-indexes layers.
+
+</li>
+    
   
 
 
@@ -1058,7 +1062,23 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#variable-colors"><code>colors</code></a></li>
+    
+      <li><a href="#variable-colors"><code>colors</code></a>  Map of colors for quick grabbing.
+
+</li>
+    
+  
+
+
+
+  
+    
+
+    
+      
+        <li><a href="http://sass-lang.com/documentation/Sass/Script/Functions.html#map_has_key-instance_method"><code>SassCore::map-has-key</code></a>  </li>
+      
+    
   
 
 
@@ -1474,7 +1494,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#mixin-size"><code>size</code></a></li>
+    
+      <li><a href="#mixin-size"><code>size</code></a>  Mixin to size elements.
+
+</li>
+    
   
 
 
@@ -1816,7 +1840,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#function-is-valid-length"><code>is-valid-length</code></a></li>
+    
+      <li><a href="#function-is-valid-length"><code>is-valid-length</code></a>  Tests whether the value is a valid length.
+
+</li>
+    
   
 
 
@@ -1997,7 +2025,10 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#mixin-position"><code>position</code></a></li>
+    
+      <li><a href="#mixin-position"><code>position</code></a>  Shorthand for positioning.
+</li>
+    
   
 
 
@@ -2160,7 +2191,10 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#mixin-position"><code>position</code></a></li>
+    
+      <li><a href="#mixin-position"><code>position</code></a>  Shorthand for positioning.
+</li>
+    
   
 
 
@@ -2308,7 +2342,10 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#mixin-position"><code>position</code></a></li>
+    
+      <li><a href="#mixin-position"><code>position</code></a>  Shorthand for positioning.
+</li>
+    
   
 
 
@@ -2464,7 +2501,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#variable-breakpoints"><code>breakpoints</code></a></li>
+    
+      <li><a href="#variable-breakpoints"><code>breakpoints</code></a>  Map of breakpoints for responsive design.
+
+</li>
+    
   
 
 
@@ -2685,7 +2726,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#mixin-absolute"><code>absolute</code></a></li>
+    
+      <li><a href="#mixin-absolute"><code>absolute</code></a>  Shorthand for absolute positioning.
+
+</li>
+    
   
 
 
@@ -2693,7 +2738,11 @@
   
     
 
-    <li><a href="#mixin-size"><code>size</code></a></li>
+    
+      <li><a href="#mixin-size"><code>size</code></a>  Mixin to size elements.
+
+</li>
+    
   
 
 
@@ -2701,7 +2750,11 @@
   
     
 
-    <li><a href="#function-opposite-direction"><code>opposite-direction</code></a></li>
+    
+      <li><a href="#function-opposite-direction"><code>opposite-direction</code></a>  Returns the opposite direction of every direction in `$directions`.
+
+</li>
+    
   
 
 
@@ -2709,7 +2762,13 @@
   
     
 
-    <li><a href="#function-z"><code>z</code></a></li>
+    
+      <li><a href="#function-z"><code>z</code></a>  Helper to manage `z-index`.
+Tries to fetch the z-index mapped to `$layer` in `$z-indexes` map.
+If found, returns it, else returns `null`.
+
+</li>
+    
   
 
 
@@ -3141,7 +3200,11 @@
       <ul class="list-unstyled">
     
 
-    <li><a href="#function-clamp"><code>clamp</code></a></li>
+    
+      <li><a href="#function-clamp"><code>clamp</code></a>  Clamp `$value` between `$min` and `$max`.
+
+</li>
+    
   
 
 

--- a/src/annotation/annotations/requires.js
+++ b/src/annotation/annotations/requires.js
@@ -1,13 +1,20 @@
 'use strict';
 
-var reqRegEx = /^\s*(?:\{(.*)\})?\s*(?:(\$?[^\s]+))?\s*(?:\((.*)\))?\s*(?:-?\s*(.*))?$/;
+var reqRegEx = /^\s*(?:\{(.*)\})?\s*(?:(\$?[^\s]+))?\s*(?:\((.*)\))?\s*(?:-?\s*([^<$]*))?\s*(?:<?\s*(.*)\s*>)?$/;
+
+function isExternal(name){
+  return name.indexOf('/') > -1 || name.indexOf(':') > -1 || name.indexOf('.') > -1;
+}
+
 module.exports = function (text) {
-  var match = reqRegEx.exec(text);
+  var match = reqRegEx.exec(text.trim());
 
   var obj = {
     type : match[1] || 'function',
     name : match[2]
   };
+
+  obj.external = isExternal(obj.name);
 
   if (obj.name.indexOf('$') === 0){
     obj.type = 'variable';
@@ -15,7 +22,11 @@ module.exports = function (text) {
   }
 
   if (match[4]){
-    obj.description = match[4];
+    obj.description = match[4].trim();
+  }
+
+  if (match[5]){
+    obj.url = match[5];
   }
 
   return obj;

--- a/src/annotation/annotations/test/requires.test.js
+++ b/src/annotation/annotations/test/requires.test.js
@@ -6,18 +6,35 @@ var assert = require('assert');
 describe('#requires', function(){
   var requires  = require('../requires.js');
   it('should default to function', function(){
-    assert.deepEqual(requires('name - description'), { type : 'function', name : 'name', description : 'description'});
-    assert.deepEqual(requires('name description'), { type : 'function', name : 'name', description : 'description'});
+    assert.deepEqual(requires('name - description'), { type : 'function', name : 'name', description : 'description', 'external': false });
+    assert.deepEqual(requires('name description'), { type : 'function', name : 'name', description : 'description', 'external': false});
   });
 
   it('should work for variables with with or without $', function(){
-    assert.deepEqual(requires('{variable} $my-variable'), { type : 'variable', name : 'my-variable'});
-    assert.deepEqual(requires('{variable} my-variable'),  { type : 'variable', name : 'my-variable'});
+    assert.deepEqual(requires('{variable} $my-variable'), { type : 'variable', name : 'my-variable', 'external': false});
+    assert.deepEqual(requires('{variable} my-variable'),  { type : 'variable', name : 'my-variable', 'external': false});
   });
 
   it('should work with optional variable type if $ is used', function(){
-    assert.deepEqual(requires('{variable} my-variable'), { type : 'variable', name : 'my-variable'});
-    assert.deepEqual(requires('$my-variable'), { type : 'variable', name : 'my-variable'});
+    assert.deepEqual(requires('{variable} my-variable'), { type : 'variable', name : 'my-variable', 'external': false});
+    assert.deepEqual(requires('$my-variable'), { type : 'variable', name : 'my-variable', 'external': false});
+  });
+
+  it('should work for external requires', function(){
+    assert.deepEqual(requires('{variable} extern::lib'), { type : 'variable', name : 'extern::lib', 'external': true});
+    assert.deepEqual(requires('extern::lib'), { type : 'function', name : 'extern::lib', 'external': true});
+    assert.deepEqual(requires('$extern::lib'), { type : 'variable', name : 'extern::lib', 'external': true});
+  });
+
+  it('should work for external requires with url', function(){
+    assert.deepEqual(requires('{variable} extern::lib - description <http://url.com>'),
+                    {'type': 'variable', 'name': 'extern::lib', 'external':true, 'description': 'description', 'url': 'http://url.com'});
+  });
+
+  it.only('should work for name and url', function(){
+    assert.deepEqual(requires('SassCore::map-has-key <http://sass-lang.com/documentation/Sass/Script/Functions.html#map_has_key-instance_method>'),
+                    {'type': 'function', 'name': 'SassCore::map-has-key', 'external':true, 'url': 'http://sass-lang.com/documentation/Sass/Script/Functions.html#map_has_key-instance_method'});
+
   });
 });
 

--- a/src/api.js
+++ b/src/api.js
@@ -41,7 +41,7 @@ exports = module.exports = {
         logger.log('Process over. Everything okay!');
       })
       .fail(function (err) {
-        console.log(err);
+        console.log(err.stack);
         throw new Error(err);
       });
   },

--- a/src/file.js
+++ b/src/file.js
@@ -267,6 +267,9 @@ exports = module.exports = {
         // Requires
         if (utils.isset(item.requires)) {
           item.requires = item.requires.map(function (req) {
+            if ( req.external === true ) {
+              return req;
+            } // Just return itself
             var lookupKey = req.type + '_' + req.name;
             if (utils.isset(index[lookupKey])) {
               var reqItem = index[lookupKey];
@@ -276,7 +279,7 @@ exports = module.exports = {
               }
 
               reqItem.usedBy.push(item);
-
+              reqItem.external = req.external;
               return reqItem;
             }
 
@@ -292,7 +295,7 @@ exports = module.exports = {
         if (utils.isset(item.see)) {
           item.see = item.see.map(function (see) {
             var lookupKey = see.type + '_' + see.name;
-            
+
             if (utils.isset(index[lookupKey])) {
               return index[lookupKey];
             }

--- a/view/scss/utils/_functions.scss
+++ b/view/scss/utils/_functions.scss
@@ -1,10 +1,10 @@
 /**
  * Returns the opposite direction of every direction in `$directions`.
- * 
+ *
  * @param {List} $directions - Positions to revert
  *
  * @throws No opposite direction found for `$direction`.
- * 
+ *
  * @return {List | Null}
  */
 @function opposite-direction($directions) {
@@ -33,13 +33,13 @@
 
 /**
  * Clamp `$value` between `$min` and `$max`.
- * 
+ *
  * @param {Number} $value - Value to clamp between `$min` and `$max`
  * @param {Number} $min   - Minimum value
  * @param {Number} $max   - Maximum value
  *
  * @throws All parameters must be numbers for `clamp`.
- * 
+ *
  * @return {Number | Null}
  */
 @function clamp($value, $min, $max) {
@@ -53,7 +53,7 @@
 
 
 /**
- * Helper to manage `z-index`. 
+ * Helper to manage `z-index`.
  * Tries to fetch the z-index mapped to `$layer` in `$z-indexes` map.
  * If found, returns it, else returns `null`.
  *
@@ -61,11 +61,11 @@
  *
  * @example scss
  * z-index: z("default")
- * 
+ *
  * @param {String} $layer - Layer
  *
  * @throws No z-index found for `$layer`.
- * 
+ *
  * @return {Number | Null}
  */
 @function z($layer) {
@@ -81,10 +81,11 @@
  * Color getter.
  *
  * @requires {variable} colors
- * 
+ * @requires SassCore::map-has-key <http://sass-lang.com/documentation/Sass/Script/Functions.html#map_has_key-instance_method>
+ *
  * @example scss
  * color: color("pink");
- * 
+ *
  * @param {String} $color - Color to fetch
  *
  * @throws No color found for `$color`. Please make sure it is defined in `$colors` map.
@@ -103,9 +104,9 @@
 
 /**
  * Tests whether the value is a valid length.
- * 
+ *
  * @param {*} $value - Value to test
- * 
+ *
  * @return {Bool}
  */
 @function is-valid-length($value) {

--- a/view/templates/includes/annotations/requires.html.swig
+++ b/view/templates/includes/annotations/requires.html.swig
@@ -1,14 +1,22 @@
 {% set title_displayed = false %}
 {% for require in item.requires %}
 
-  {% if (display.access.indexOf(require.access[0]) != -1) and not (not display.alias and require.alias[0]) %}
+  {% if (display.access.indexOf(require.access[0]) != -1) and not (not display.alias and require.alias[0]) or require.external %}
     {% if not title_displayed %}
       {% set title_displayed = true %}
       <h3 class="item__sub-heading">Requires</h3>
       <ul class="list-unstyled">
     {% endif %}
 
-    <li><a href="#{{ require.context.type }}-{{ require.context.name }}"><code>{{ require.context.name }}</code></a></li>
+    {% if require.external %}
+      {% if require.url %}
+        <li><a href="{{ require.url}}"><code>{{ require.name }}</code></a>  {{ require.description }}</li>
+      {% else %}
+        <li>{{ require.name }} {{ require.description }}</li>
+      {% endif %}
+    {% else %}
+      <li><a href="#{{ require.context.type }}-{{ require.context.name }}"><code>{{ require.context.name }}</code></a>  {{ require.description }}</li>
+    {% endif %}
   {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
``` scss
/**
 * @requires {type} name - description <url>
 */
```

Where:
- the hyphen is optional, as stated in #81 
- an external ref must contain `/`, `::` or `.`
- the `url` is the `href` for the link

the `@requires` annotation will now include the `url` and `external` property. 
