### PR TITLE
Add support for description 

### DIFF
--- a/src/annotation/annotations/example.js
+++ b/src/annotation/annotations/example.js
@@ -4,9 +4,12 @@
  * @example is a multiline annotation
  * check if there is something on the first line and use it as the type information
  *
- * @example html
+ * @example html - description
  * <div></div>
  */
+
+var descRegEx = /(\w+)\s*(?:-?\s*(.*))/;
+
 module.exports = {
   parse : function (text) {
     var example = {
@@ -18,7 +21,11 @@ module.exports = {
     var optionalType = text.substr(0, text.indexOf('\n'));
 
     if (optionalType.trim().length !== 0) {
-      example.type = optionalType;
+      var typeDesc = descRegEx.exec(optionalType);
+      example.type = typeDesc[1];
+      if (typeDesc[2].length !== 0) {
+        example.description = typeDesc[2];
+      }
       example.code = text.substr(optionalType.length + 1); // Remove the type
     }
 

--- a/test/annotations/example.test.js
+++ b/test/annotations/example.test.js
@@ -16,7 +16,10 @@ describe('#example', function () {
     assert.deepEqual(example.parse('\nsome code\n'), { type: 'scss', code: 'some code' });
   });
 
-  it('should use first line as type', function () {
+  it.only('should extract type and description from first line', function () {
     assert.deepEqual(example.parse('type\nsome code'), { type: 'type', code: 'some code' });
+    assert.deepEqual(example.parse('type - description\nsome code'), { type: 'type', description : 'description', code: 'some code' });
+    assert.deepEqual(example.parse('type description\nsome code'), { type: 'type', description : 'description', code: 'some code' });
   });
+
 });


### PR DESCRIPTION
I implemented  #145 like this:

The data object returned by `@example` looks like

``` js
{
  type : 'scss',
  description : 'description', // new key
  code : 'code'
}
```

Supporting this syntax 

```
@example scss - How to clamp a number.
```

and without the `-` because the `type` should always be a single word. 

```
@example scss How to clamp a number.
```
