### PR TITLE
fix(alias): correct object access and test keys

### DIFF
--- a/src/annotation/annotations/alias.js
+++ b/src/annotation/annotations/alias.js
@@ -1,32 +1,37 @@
 'use strict';
+
 var utils = require('../../utils');
 var logger = require('../../log');
 
 module.exports = {
-  parse : function (text) {
+
+  parse: function (text) {
     return text.trim();
   },
 
-  resolve : function (byTypeAndName) {
-
-    utils.eachItem(byTypeAndName, function (item){
+  resolve: function (byTypeAndName) {
+    utils.eachItem(byTypeAndName, function (item) {
       if (utils.isset(item.alias)) {
         item.alias.forEach(function (alias) {
-          if (utils.isset(byTypeAndName[alias.type]) &&
-              utils.isset(byTypeAndName[alias.type][alias.name])) {
 
-            if (!Array.isArray(byTypeAndName[alias.type][alias.name].aliased)) {
-             byTypeAndName[alias.type][alias.name].aliased = [];
+          var type = item.context.type;
+          var name = item.context.name;
+
+          if (utils.isset(byTypeAndName[type]) &&
+              utils.isset(byTypeAndName[type][alias])) {
+
+            if (!Array.isArray(byTypeAndName[type][alias].aliased)) {
+              byTypeAndName[type][alias].aliased = [];
             }
 
-            byTypeAndName[alias.type][alias.name].aliased.push(item.context.name);
+            byTypeAndName[type][alias].aliased.push(name);
 
-          } else {
-            logger.log('Item `' + item.context.name + '` is an alias of `' + alias + '` but this item doesn\'t exist.');
+          }
+          else {
+            logger.log('Item `' + name + '` is an alias of `' + alias + '` but this item doesn\'t exist.');
           }
         });
       }
     });
-
   }
 };


### PR DESCRIPTION
The keys for accessing and testing against the aliased item were wrong, but this was producing no error since it was choked by the `if` condition.

Result, no `item.aliased`, thus no alias annotations where displayed.

@FWeinb please review
- Refs #151
