### PR TITLE
Backport, fixed `found-at` with absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.6
+
+* Backport, fixed `found-at` with absolute path ([#155](https://github.com/SassDoc/sassdoc/pull/155))
+
 ## 1.1.5
 
 * Fixed `@example` not being printed for variables ([#146](https://github.com/SassDoc/sassdoc/pull/146))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     { "name": "Valérian Galliat", "url": "https://twitter.com/valeriangalliat" },
     { "name": "Pascal Duez", "url": "https://twitter.com/pascalduez" }
   ],
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": {
     "type": "MIT",
     "url": "http://opensource.org/licenses/MIT"

--- a/src/file.js
+++ b/src/file.js
@@ -161,7 +161,7 @@ exports = module.exports = {
         Object.keys(data).forEach(function (key) {
           data[key].forEach(function (item) {
             item.file = {
-              path: utils.getDisplayPath(file, exports.folder.base),
+              path: path.relative(exports.folder.base, file),
               name: path.basename(file, '.scss')
             };
           });
@@ -209,7 +209,7 @@ exports = module.exports = {
    * @param {String} folder - folder path
    */
   getData: function (folder) {
-    exports.folder.base = path.basename(folder);
+    exports.folder.base = folder;
 
     return exports.folder.parse(folder).then(function (response) {
       response = response || [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,20 +7,10 @@ exports = module.exports = {
   /**
    * Get file extension
    * @param  {string} filename - filename to retrieve extension from
-   * @return {string}            extension
+   * @return {string} extension
    */
   getExtension: function (filename) {
     return path.extname(filename).substr(1);
-  },
-
-  /**
-   * Get file display path, relative to the project directory
-   * @param  {string} filePath - file path
-   * @param  {string} baseDir  - project base directory
-   * @return {string}            display path
-   */
-  getDisplayPath: function (filePath, baseDir) {
-    return path.join(baseDir, filePath);
   },
 
   /**


### PR DESCRIPTION
- Refs SassDoc/gulp-sassdoc#2

See
abe4fd3ef8d7a3540446b29e041c6214d4618ff0
74d34316ff22f968cc0b4ea89f253486b9a96891
2c970528c71d94c18d9d1e758e19fda2a0dcbace
