### PR TITLE
Add `allowedOnType` to annotations

### DIFF
--- a/src/annotation/annotations/content.js
+++ b/src/annotation/annotations/content.js
@@ -23,5 +23,5 @@ module.exports = {
     });
   },
 
-  allowedOnType : ['mixin']
+  allowedOn : ['mixin']
 };

--- a/src/annotation/annotations/output.js
+++ b/src/annotation/annotations/output.js
@@ -7,5 +7,5 @@ module.exports = {
 
   alias: ['outputs'],
 
-  allowedOnType : ['mixin']
+  allowedOn : ['mixin']
 };

--- a/src/annotation/annotations/parameters.js
+++ b/src/annotation/annotations/parameters.js
@@ -25,5 +25,7 @@ module.exports = {
 
     return obj;
   },
-  alias: ['arg', 'arguments', 'param']
+  alias: ['arg', 'arguments', 'param'],
+
+  allowedOn : ['function', 'mixin']
 };

--- a/src/annotation/annotations/prop.js
+++ b/src/annotation/annotations/prop.js
@@ -26,6 +26,7 @@ module.exports = {
     return obj;
   },
 
-  alias: ['property']
+  alias: ['property'],
 
+  allowedOn: ['variable']
 };

--- a/src/annotation/annotations/returns.js
+++ b/src/annotation/annotations/returns.js
@@ -28,5 +28,5 @@ module.exports = {
 
   alias: ['return'],
 
-  allowedOnType : ['function', 'mixin']
+  allowedOn : ['function']
 };

--- a/src/annotation/annotations/type.js
+++ b/src/annotation/annotations/type.js
@@ -3,5 +3,7 @@
 module.exports = {
   parse: function (text) {
     return text.trim();
-  }
+  },
+
+  allowedOn : ['variable']
 };


### PR DESCRIPTION
Since version `0.3.1` cdocparser supports the `allowedOnType` key. I added it to:
- `@content` => ['mixin']
- `@output` => ['mixin']
- `@returns` => ['function', 'mixn']

These annotations will be ignored on all other types and a warning will be generated. 
