### PR TITLE
Support for `config.exclude` patterns

### DIFF
--- a/src/exclude.js
+++ b/src/exclude.js
@@ -1,0 +1,16 @@
+let through = require('through2');
+let minimatch = require('minimatch');
+
+/**
+ * @param {Array} patterns
+ * @return {Object}
+ */
+export default function exclude(patterns) {
+  return through.obj((chunk, enc, cb) => {
+    if (patterns.find(x => minimatch(chunk.relative, x))) {
+      return cb();
+    }
+
+    cb(null, chunk);
+  });
+}

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -9,6 +9,7 @@ let Logger = require('./logger').default;
 let Parser = require('./parser').default;
 let sort = require('./sorter').default;
 let recurse = require('./recurse').default;
+let exclude = require('./exclude').default;
 
 export default function sassdoc(src, dest, config = {}) {
   let logger = config.logger = config.logger || new Logger();
@@ -62,6 +63,7 @@ export function parse(src, config = {}) {
 
   vfs.src(src)
     .pipe(recurse())
+    .pipe(exclude(config.exclude || []))
     .pipe(parseFilter);
 
   return parseFilter.promise.then(data => sort(data));


### PR DESCRIPTION
Example `.sassdocrc`:

```
exclude:
  - scss/utils/_functions.scss
  - scss/{private,exclude}/**
  - scss/vendor/**
```

See #228.
