### PR TITLE
Add a helpful warning message when nothing could be documented

### DIFF
--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -120,6 +120,17 @@ export default function sassdoc(...args) {
 
     let data = await baseDocumentize(env);
 
+    if (!data.length) {
+      env.emit('warning', new errors.Warning(`SassDoc could not find anything to document.
+
+  * Are you still using \`/**\` comments? They're no more supported since 2.0.
+    See <http://sassdoc.com/upgrading/#c-style-comments>.
+  * Are you documenting actual Sass items (variables, functions, mixins, placeholders)?
+    SassDoc doesn't support documenting CSS selectors.
+    See <http://sassdoc.com/frequently-asked-questions/#does-sassdoc-support-css-classes-and-ids->.
+`));
+    }
+
     try {
       await refresh(env);
       await theme(env);


### PR DESCRIPTION
Example:

```
» Folder "bin" successfully parsed.
» [WARNING] SassDoc could not find anything to document.

  * Are you still using `/**` comments? They're no more supported since 2.0.
    See <http://sassdoc.com/upgrading/#c-style-comments>.
  * Are you documenting actual Sass items (variables, functions, mixins, placeholders)?
    SassDoc doesn't support documenting CSS selectors.
    See <http://sassdoc.com/frequently-asked-questions/#does-sassdoc-support-css-classes-and-ids->.

» Folder "sassdoc" successfully refreshed.
» Theme "default" successfully rendered.
» Process over. Everything okay!
✓ SassDoc completed after 79ms
```

The current link to `upgrading/#c-style-comments` is broken, but I assume here the development version of the website will be deployed in production.