### PR TITLE
Use backticks instead of double quotes in messages

### DIFF
--- a/src/annotation/annotations/alias.js
+++ b/src/annotation/annotations/alias.js
@@ -18,7 +18,7 @@ export default function alias(env) {
         let aliasedItem = data.find(i => i.context.name === alias);
 
         if (aliasedItem === undefined) {
-          env.logger.warn(`Item "${name}" is an alias of "${alias}" but this item doesn't exist.`);
+          env.logger.warn(`Item \`${name}\` is an alias of \`${alias}\` but this item doesn't exist.`);
           return;
         }
 

--- a/src/annotation/annotations/require.js
+++ b/src/annotation/annotations/require.js
@@ -131,7 +131,7 @@ export default function (env) {
           if (reqItem === undefined) {
             if (!req.autofill) {
               env.logger.warn(
-                `Item "${item.context.name}" requires "${req.name}" from type "${req.type}" but this item doesn't exist.`
+                `Item \`${item.context.name}\` requires \`${req.name}\` from type \`${req.type}\` but this item doesn't exist.`
               );
             }
 

--- a/src/annotation/annotations/see.js
+++ b/src/annotation/annotations/see.js
@@ -38,7 +38,7 @@ export default function see(env) {
             return seeItem;
           }
 
-          env.logger.warn(`Item "${item.context.name}" refers to "${see.name}" from type "${see.type}" but this item doesn't exist.`);
+          env.logger.warn(`Item \`${item.context.name}\` refers to \`${see.name}\` from type \`${see.type}\` but this item doesn't exist.`);
         })
           .filter(x => x !== undefined);
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -78,7 +78,7 @@ export default class Environment extends EventEmitter {
     for (let k of Object.keys(config)) {
       if (k in this) {
         return this.emit('error', new Error(
-          `Reserved configuration key "${k}".`
+          `Reserved configuration key \`${k}\`.`
         ));
       }
 
@@ -104,7 +104,7 @@ export default class Environment extends EventEmitter {
     this.file = file;
 
     if (!this.tryLoadCurrentFile()) {
-      this.emit('warning', new errors.Warning(`Config file "${file}" not found.`));
+      this.emit('warning', new errors.Warning(`Config file \`${file}\` not found.`));
       this.logger.warn('Falling back to `.sassdocrc`');
       this.loadDefaultFile();
     }
@@ -158,7 +158,7 @@ export default class Environment extends EventEmitter {
       return;
     }
 
-    this.emit('warning', new errors.Warning(`Package file "${file}" not found.`));
+    this.emit('warning', new errors.Warning(`Package file \`${file}\` not found.`));
     this.logger.warn('Falling back to `package.json`.');
 
     file = this.resolve('package.json');
@@ -198,7 +198,7 @@ export default class Environment extends EventEmitter {
     try {
       require.resolve(module);
     } catch (err) {
-      this.emit('warning', new errors.Warning(`Theme "${this.theme}" not found.`));
+      this.emit('warning', new errors.Warning(`Theme \`${this.theme}\` not found.`));
       this.logger.warn('Falling back to default theme.');
       return this.defaultTheme();
     }

--- a/src/logger.js
+++ b/src/logger.js
@@ -142,7 +142,7 @@ export function checkLogger(logger) {
     .filter(x => !(x in logger) || !is.function(logger[x]));
 
   if (methods.length) {
-    const missing = `"${methods.join('", "')}"`;
+    const missing = `"${methods.join('\`, \`')}"`;
     const s = methods.length > 1 ? 's' : '';
 
     throw new errors.SassDocError(`Invalid logger, missing ${missing} method${s}`);

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -82,7 +82,7 @@ export default function sassdoc(...args) {
     })
       .then(() => mkdir(env.dest))
       .then(() => {
-        env.logger.log(`Folder "${env.dest}" successfully refreshed.`);
+        env.logger.log(`Folder \`${env.dest}\` successfully refreshed.`);
       })
       .catch(err => {
         // Friendly error for already existing directory.
@@ -105,7 +105,7 @@ export default function sassdoc(...args) {
     return promise
       .then(() => {
         let themeName = env.themeName || 'anonymous';
-        env.logger.log(`Theme "${themeName}" successfully rendered.`);
+        env.logger.log(`Theme \`${themeName}\` successfully rendered.`);
       });
   }
 
@@ -248,7 +248,7 @@ async function baseDocumentize(env) { // jshint ignore:line
 
   filter.promise
     .then(data => {
-      env.logger.log(`Folder "${env.src}" successfully parsed.`);
+      env.logger.log(`Folder \`${env.src}\` successfully parsed.`);
       env.data = data;
 
       env.logger.debug(() => {
@@ -257,7 +257,7 @@ async function baseDocumentize(env) { // jshint ignore:line
           JSON.stringify(data, null, 2) + '\n'
         );
 
-        return 'Dumping data to "sassdoc-data.json".';
+        return 'Dumping data to `sassdoc-data.json`.';
       });
     });
 


### PR DESCRIPTION
Since an upgrade of JSHint, it does not complain anymore about escaped backticks inside backtick strings.