### PR TITLE
Update to 6to5@3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PATH := node_modules/.bin:$(PATH)
 SASSDOC = bin/sassdoc
 MOCHA = node_modules/.bin/_mocha
-TO5_FLAGS = --experimental
+TO5_FLAGS = --experimental --loose all --optional selfContained
 
 all: dist lint test
 

--- a/bin/sassdoc
+++ b/bin/sassdoc
@@ -2,6 +2,4 @@
 
 'use strict';
 
-require('../polyfill');
-
 require('../dist/cli')(process.argv.slice(2));

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
 'use strict';
 
-require('./polyfill');
-
 module.exports = require('./dist/sassdoc');

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "vinyl-source-stream": "^1.0.0"
   },
   "devDependencies": {
-    "6to5": "^2.9.4",
+    "6to5": "^3.0.11",
     "coveralls": "^2.11.2",
     "dateformat": "^1.0.11",
     "istanbul": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -78,9 +78,9 @@
     "README.md"
   ],
   "dependencies": {
+    "6to5-runtime": "^3.0.12",
     "chalk": "^0.5.0",
     "concat-stream": "^1.4.7",
-    "core-js": "^0.4.3",
     "docopt": "^0.4.1",
     "glob": "^4.3.1",
     "glob2base": "0.0.12",
@@ -90,7 +90,6 @@
     "minimatch": "^2.0.0",
     "mkdirp": "^0.5.0",
     "multipipe": "^0.1.2",
-    "regenerator": "^0.8.3",
     "rimraf": "^2.2.8",
     "safe-wipe": "0.*",
     "sass-convert": "^0.4.0",

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,2 +1,0 @@
-require('core-js/shim');
-require('regenerator/runtime');

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -1,3 +1,4 @@
+/* global sassdoc */
 const { denodeify, is, g2b } = require('./utils');
 
 const Environment = require('./environment');
@@ -21,44 +22,19 @@ const through = require('through2');
 /**
  * Expose lower API blocks.
  */
-export { Environment, Logger, Parser, sorter, errors };
+sassdoc.Environment = Environment;
+sassdoc.Logger = Logger;
+sassdoc.Parser = Parser;
+sassdoc.sorter = sorter;
+sassdoc.errors = errors;
 
 /**
- * Boostrap Parser and AnnotationsApi, execute parsing phase.
- * @return {Stream}
- * @return {Promise} - as a property of Stream.
+ * Expose core function
  */
-export function parseFilter(env = {}) {
-  env = ensureEnvironment(env);
+sassdoc.parseFilter = parseFilter;
+sassdoc.ensureEnvironment = ensureEnvironment;
+sassdoc.parse = parse;
 
-  let parser = new Parser(env, env.theme && env.theme.annotations);
-  let filter = parser.stream();
-
-  filter.promise
-    .then(data => sorter(data));
-
-  return filter;
-}
-
-/**
- * Ensure a proper Environment Object and events.
- * @return {Object}
- */
-export function ensureEnvironment(config, onError = e => { throw e; }) {
-  if (config instanceof Environment) {
-    config.on('error', onError);
-    return config;
-  }
-
-  let logger = ensureLogger(config);
-  let env = new Environment(logger, config.strict);
-
-  env.on('error', onError);
-  env.load(config);
-  env.postProcess();
-
-  return env;
-}
 
 /**
  * Default public API method.
@@ -184,13 +160,50 @@ export default function sassdoc(...args) {
 }
 
 /**
+ * Boostrap Parser and AnnotationsApi, execute parsing phase.
+ * @return {Stream}
+ * @return {Promise} - as a property of Stream.
+ */
+function parseFilter(env = {}) {
+  env = ensureEnvironment(env);
+
+  let parser = new Parser(env, env.theme && env.theme.annotations);
+  let filter = parser.stream();
+
+  filter.promise
+    .then(data => sorter(data));
+
+  return filter;
+}
+
+/**
+ * Ensure a proper Environment Object and events.
+ * @return {Object}
+ */
+function ensureEnvironment(config, onError = e => { throw e; }) {
+  if (config instanceof Environment) {
+    config.on('error', onError);
+    return config;
+  }
+
+  let logger = ensureLogger(config);
+  let env = new Environment(logger, config.strict);
+
+  env.on('error', onError);
+  env.load(config);
+  env.postProcess();
+
+  return env;
+}
+
+/**
  * Parse and return data object.
  * @param {String | Array} src
  * @param {Object} env
  * @return {Promise | Stream}
  * @see srcEnv
  */
-export function parse(...args) { // jshint ignore:line
+function parse(...args) { // jshint ignore:line
   /* jshint ignore:start */
 
   return srcEnv(documentize, stream)(...args);

--- a/test/annotations/access.test.js
+++ b/test/annotations/access.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
+
 describe('#access', function () {
   var access = (new (require('../../dist/annotation'))()).list.access;
   it('should return the trimmed string', function () {

--- a/test/annotations/alias.test.js
+++ b/test/annotations/alias.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#alias', function () {

--- a/test/annotations/author.test.js
+++ b/test/annotations/author.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#author', function () {

--- a/test/annotations/content.test.js
+++ b/test/annotations/content.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#content', function () {

--- a/test/annotations/defaults.test.js
+++ b/test/annotations/defaults.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 var File = require('vinyl');
 var sassdoc = require('../../');

--- a/test/annotations/deprecated.test.js
+++ b/test/annotations/deprecated.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#deprecated', function () {

--- a/test/annotations/example.test.js
+++ b/test/annotations/example.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#example', function () {

--- a/test/annotations/group.test.js
+++ b/test/annotations/group.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#group', function () {

--- a/test/annotations/ignore.test.js
+++ b/test/annotations/ignore.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#ignore', function () {

--- a/test/annotations/link.test.js
+++ b/test/annotations/link.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#link', function () {

--- a/test/annotations/output.test.js
+++ b/test/annotations/output.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#output', function () {

--- a/test/annotations/parameter.test.js
+++ b/test/annotations/parameter.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#parameter', function () {

--- a/test/annotations/property.test.js
+++ b/test/annotations/property.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#property', function () {

--- a/test/annotations/require.test.js
+++ b/test/annotations/require.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#require', function () {

--- a/test/annotations/return.test.js
+++ b/test/annotations/return.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#return', function () {

--- a/test/annotations/see.test.js
+++ b/test/annotations/see.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#see', function () {

--- a/test/annotations/since.test.js
+++ b/test/annotations/since.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#since', function () {

--- a/test/annotations/throw.test.js
+++ b/test/annotations/throw.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#throw', function () {

--- a/test/annotations/todo.test.js
+++ b/test/annotations/todo.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#todo', function () {

--- a/test/annotations/type.test.js
+++ b/test/annotations/type.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 
 describe('#type', function () {

--- a/test/api/exclude.test.js
+++ b/test/api/exclude.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 var vfs = require('vinyl-fs');
 var through = require('through2');

--- a/test/init.js
+++ b/test/init.js
@@ -1,3 +1,0 @@
-'use strict';
-
-require('../polyfill');

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('./init');
-
 var path = require('path');
 var fs = require('fs');
 var inherits = require('util').inherits;

--- a/test/utils/errors.test.js
+++ b/test/utils/errors.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 var errors = require('../../dist/errors');
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('../init');
-
 var assert = require('assert');
 var fs = require('fs');
 var utils = require('../../dist/utils');


### PR DESCRIPTION
I could keep the changes made to the sassdoc code minimal. 

In `sassdoc.js` i choose to only export the sassdoc function like `export default sassdoc()` and append every export to it. (See [here](https://github.com/SassDoc/sassdoc/blob/62ea3be74f3b3b6b8fa9bba2dcc6e608a75a0f52/src/sassdoc.js#L22-L36))

The `logger.js` had to be updated to use `static` functions instead of multiple exports.

I could get ride of some boilerplate code in every test case because our es6 code dons't care about a polyfill anymore, because i choose to use the `--optional selfContained` flag.

@SassDoc/owners Let's review