### PR TITLE
[WIP] Default to `./` when no `<src>` and support `-` as `stdin`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ test: test/data/expected.stream.json dist
 	mocha test/env/*.test.js test/utils/*.test.js
 	rm -rf sassdoc && $(MOCHA) test/api/*.test.js
 	$(SASSDOC) --parse test/data/test.scss | diff - test/data/expected.json
-	$(SASSDOC) --parse < test/data/test.scss | diff - test/data/expected.stream.json
+	$(SASSDOC) --parse - < test/data/test.scss | diff - test/data/expected.stream.json
+	cd test/data && $(SASSDOC) --parse | diff - expected.json
 	rm -rf sassdoc && $(SASSDOC) test/data/test.scss && [ -d sassdoc ]
-	rm -rf sassdoc && $(SASSDOC) < test/data/test.scss && [ -d sassdoc ]
+	rm -rf sassdoc && $(SASSDOC) - < test/data/test.scss && [ -d sassdoc ]
 
 test/data/expected.stream.json: test/data/expected.json
 	test/data/stream $< > $@

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "concat-stream": "^1.4.7",
     "core-js": "^0.4.3",
     "docopt": "^0.4.1",
+    "event-stream": "^3.2.1",
     "glob": "^4.3.1",
     "glob2base": "0.0.12",
     "js-yaml": "^3.2.1",

--- a/src/recurse.js
+++ b/src/recurse.js
@@ -10,7 +10,7 @@ const vfs = require('vinyl-fs');
  */
 export default function recurse() {
   return through.obj(function (file, enc, cb) {
-    if (file.isBuffer()) {
+    if (file.isBuffer() || file.isStream()) {
       // Pass-through.
       return cb(null, file);
     }


### PR DESCRIPTION
* See #347

Usage:

```sh
sassdoc # Document the CWD
cat file.scss | sassdoc - # Document `stdin`
cat file.scss | sassdoc - src/ # Document both `stdin` and `src/` (we still support multiple `<src>`
```

This implies streamlining the behavior of `sassdoc(src)` and `.pipe(sassdoc())`, especially supporting `recurse`, `exclude` and `converter` in the streaming version.

While I think it's good to have the same behavior in both usages, it's maybe harmful for plugins usage?

Anyway, we're about to release 2.0 and this feature have not been heavily tested, so it's not a good idea to merge it right away.

Though, we need to be concerned about not breaking the API, that is, if we plan to have this default `./` and `-` support in 2.0, we need to at least add the default directory and drop the `stdin` support before releasing 2.0.

But I'm afraid the behavior streamlining between `sassdoc(src)` and `.pipe(sassdoc())` can be considered as a breaking change too, and if we want this, we might not be able to use it until 3.0.

**Note:** according to #347, this PR is missing a default exclude pattern when using the CWD (to not documentize `node_modules` and other vendor directories, and I'd also avoid documenting the destination directory if it's contained in CWD, even if it's not supposed to contain Sass files).

Opinions?