### PR TITLE
Sort data directly from the parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,6 +1,7 @@
 import { defer } from './utils';
 import * as errors from './errors';
 import AnnotationsApi from './annotation';
+import sorter from './sorter';
 
 const ScssCommentParser = require('scss-comment-parser');
 const through = require('through2');
@@ -27,6 +28,8 @@ export default class Parser {
    * Called with all found annotations except with type "unkown".
    */
   postProcess(data) {
+    data = sorter(data);
+
     Object.keys(this.annotations.list).forEach(key => {
       let annotation = this.annotations.list[key];
 

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -36,9 +36,6 @@ export function parseFilter(env = {}) {
   let parser = new Parser(env, env.theme && env.theme.annotations);
   let filter = parser.stream();
 
-  filter.promise
-    .then(data => sorter(data));
-
   return filter;
 }
 


### PR DESCRIPTION
* See #352

It's useful to have a deterministic output, for example I needed this to [compare different branchs of the theme](https://github.com/SassDoc/sassdoc-theme-default/pull/58#issuecomment-72356748).

The `sorter` export is not needed anymore since the parsed data will always be sorted (and again, that's nice for *determinism*). Though I can't remove this export because it would break the API.

I don't believe it's a problem since it won't cause any problem if someone's using the parser/sorter "by and" and the data end up sorted twice.

And the fact the data don't comes out from the parser in a random order anymore is not breaking, since the interface stays the same.