### PR TITLE
Improve development instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,9 +4,16 @@
 
 ```sh
 # Clone the repository on your machine
-# If you don't have a SSH key, feel free to clone using HTTPS instead:
-# git clone https://github.com/SassDoc/sassdoc.git
 git clone git@github.com:SassDoc/sassdoc.git
+
+# If you don't have a SSH key, feel free to clone using HTTPS instead
+# git clone https://github.com/SassDoc/sassdoc.git
+
+# If you're not a SassDoc organisation member and you forked the repo,
+# you need to clone `yourname/sassdoc.git` instead.
+#
+# Also add actual SassDoc repo as `upstream` to fetch code updates:
+git remote add upstream https://github.com/SassDoc/sassdoc.git
 
 # Head into the local repository
 cd sassdoc
@@ -21,90 +28,159 @@ npm install
 make
 ```
 
-One liner (with SSH):
+## How to develop a feature
 
 ```sh
-git clone git@github.com:SassDoc/sassdoc.git && cd sassdoc && git checkout develop && npm install && make
+# Be sure to be on an up-to-date `develop`
+git checkout develop
+git pull
+
+# If you're on a fork, be sure to pull the `upstream` version
+git pull upstream develop
+
+# Create a new feature branch
+git checkout -b feature/my-new-feature
+
+# Add some work
+
+# Make a beautiful commit, reference related issues if needed
+git commit
+
+# Push your branch
+git push -u origin feature/my-new-feature
+
+# Then make a pull request (targeting `develop`)!
+```
+
+## How to make an hotfix
+
+```sh
+# Be sure to be on an up-to-date `master`
+git checkout master
+git pull
+
+# If you're on a fork, be sure to pull the `upstream` version
+git pull upstream master
+
+# Create a new hotfix branch
+git checkout -b hotfix/my-new-hotfix
+
+# Add the actual fix
+
+# Commit the fix, reference related issues
+git commit
+
+# Push your branch
+git push -u origin hotfix/my-new-hotfix
+
+# Make a pull request if it's relevant
+```
+
+## How to merge an hotfix
+
+```sh
+# Merge in `master`
+git checkout master
+git pull
+git merge --no-ff hotfix/hotfix-to-merge
+
+# Tag the hotfix version (patch should be bumped in branch)
+git tag <version>
+
+# Push
+git push
+git push --tags
+
+# Merge in `develop` and push
+git checkout develop
+git pull
+git merge --no-ff hotfix/hotfix-to-merge
+git push
+
+# Delete hotfix branch
+git branch -d hotfix/hotfix-to-merge
+git push origin :hotfix/hotfix-to-merge
 ```
 
 ## How to release a new version
 
 ```sh
-# Move to `develop` branch
+# Move to `develop` branch and get latest changes
 git checkout develop
+git pull
 
 # Bump version number in `package.json`
 vim package.json
-
-# Run tests one last time and publish the package
-make publish
 
 # Commit the change in `package.json`
 git add package.json
 git commit -m 'Bump <version>'
 
-# Push to the repository
-git push origin develop
+# Push on `develop`
+git push
 
 # Head to `master`
 git checkout master
 
-# Sync `master` to `develop` level
-git reset --hard origin/develop
+# Merge `develop` branch
+git merge --no-ff develop
 
-# Push to the repository
-git push origin master --force
+# Tag the commit
+git tag <version>
+
+# Run tests one last time and publish the package
+make publish
+
+# Push
+git push
+git push --tags
 ```
 
 Then on GitHub, [add a new release](https://github.com/SassDoc/sassdoc/releases/new) with both *Tag version* and *Release title* matching the new version. The *description* should be the changelog.
 
 ## How to release a pre-version
 
-Same as [How to release a new version](#how-to-release-a-new-version) except for the `npm publish` command:
+Same as [How to release a new version](#how-to-release-a-new-version) except it's not merged in `master` and the `npm publish` is slightly different:
 
 ```sh
-# Move to `develop` branch
+# Move to `develop` branch and get latest changes
 git checkout develop
+git pull
 
 # Bump version number in `package.json`
 vim package.json
+
+# Commit the change in `package.json`
+git add package.json
+git commit -m 'Bump <version>'
+
+# Push on `develop`
+git push
 
 # Run tests one last time
 make test
 
 # Publish the package
-npm publish --tag rc.<rc_number>
-
-# Commit the change in `package.json`
-git add package.json && git commit -m "Bump <version>"
-
-# Push to the repository
-git push origin develop
-```
-
-Shortened commands (although it's recommanded to do it step by step to prevent any unfortunate mistake):
-
-```sh
-# Don't forget to replace <version> and <rc_number> with the actual version number and RC number
-git checkout develop && vim package.json && make test && npm publish --tag rc.<rc_number> && git add package.json && git commit -m "Bump <version>-rc.<rc_number>" && git push origin develop
+npm publish --tag beta
 ```
 
 ## How to work on the theme
 
 ```sh
-# Make sure you have the latest version of SassDoc (CR included)
+# Make sure you have the latest version of SassDoc
 npm update sassdoc -g
 
 # Clone the repository on your machine
-# If you don't have a SSH key, feel free to clone using HTTPS instead:
-# git clone https://github.com/SassDoc/sassdoc-theme-default.git
 git clone git@github.com:SassDoc/sassdoc-theme-default.git
+
+# If you don't have a SSH key, feel free to clone using HTTPS instead
+# git clone https://github.com/SassDoc/sassdoc-theme-default.git
 
 # Head into the local repository
 cd sassdoc-theme-default
 
 # Run all Make tasks
-make all
+make
 
 # Run SassDoc
 sassdoc scss/ --theme ./ --verbose
@@ -116,4 +192,3 @@ When you make a change:
 # Run all Make tasks and SassDoc
 make all && sassdoc scss/ --theme ./ --verbose
 ```
-


### PR DESCRIPTION
* Remove potentially dangerous one-liners.
* Describe feature branches and hotfixes.
* Assume the reader is might be forking SassDoc.
* Remove hard reset and force push on `master` when publishing. New feature and hotfixes instructions should prevent this.