### PR TITLE
Do not try to autofill explicit access

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "url": "https://twitter.com/pascalduez"
     }
   ],
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": {
     "type": "MIT",
     "url": "http://opensource.org/licenses/MIT"

--- a/src/annotation/annotations/access.js
+++ b/src/annotation/annotations/access.js
@@ -10,6 +10,10 @@ export default function access(env) {
     },
 
     autofill(item) {
+      if (item.access !== 'auto') {
+        return;
+      }
+
       if (env.privatePrefix === false) {
         return;
       }
@@ -24,10 +28,11 @@ export default function access(env) {
         return 'private';
       }
 
+      return 'public';
     },
 
     default() {
-      return 'public';
+      return 'auto';
     },
 
     multiple: false,

--- a/test/annotations/access.test.js
+++ b/test/annotations/access.test.js
@@ -14,22 +14,28 @@ describe('#access', function () {
   });
 
   it('should autofill based on default', function () {
-    assert.equal(access.autofill({ context: { name: 'non-private'}, access: 'public'}), undefined);
-    assert.equal(access.autofill({ context: { name: '_private-name'}, access: 'public'}), 'private');
-    assert.equal(access.autofill({ context: { name: '-private-name'}, access: 'public'}), 'private');
+    assert.equal(access.autofill({ context: { name: 'non-private'}, access: 'auto'}), 'public');
+    assert.equal(access.autofill({ context: { name: '_private-name'}, access: 'auto'}), 'private');
+    assert.equal(access.autofill({ context: { name: '-private-name'}, access: 'auto'}), 'private');
   });
 
   it('should ignore autofill if privatePrefix is false', function () {
     var accessEnv = accessCtor({ privatePrefix: false });
-    assert.equal(accessEnv.autofill({ context: { name: 'non-private'}, access: 'public'}), undefined);
-    assert.equal(accessEnv.autofill({ context: { name: '_private-name'}, access: 'public'}), undefined);
-    assert.equal(accessEnv.autofill({ context: { name: '-private-name'}, access: 'public'}), undefined);
+    assert.equal(accessEnv.autofill({ context: { name: 'non-private'}, access: 'auto'}), undefined);
+    assert.equal(accessEnv.autofill({ context: { name: '_private-name'}, access: 'auto'}), undefined);
+    assert.equal(accessEnv.autofill({ context: { name: '-private-name'}, access: 'auto'}), undefined);
   });
 
   it('should autofill based on privatePrefix', function () {
     var accessEnv = accessCtor({ privatePrefix: '^--' });
-    assert.equal(accessEnv.autofill({ context: { name: '-non-private'}, access: 'public'}), undefined);
-    assert.equal(accessEnv.autofill({ context: { name: '_non-private'}, access: 'public'}), undefined);
-    assert.equal(accessEnv.autofill({ context: { name: '--private-name'}, access: 'public'}), 'private');
+    assert.equal(accessEnv.autofill({ context: { name: '-non-private'}, access: 'auto'}), 'public');
+    assert.equal(accessEnv.autofill({ context: { name: '_non-private'}, access: 'auto'}), 'public');
+    assert.equal(accessEnv.autofill({ context: { name: '--private-name'}, access: 'auto'}), 'private');
+  });
+
+  it('should respect explicit access', function () {
+    assert.equal(access.autofill({ context: { name: 'non-private'}, access: 'public'}), undefined);
+    assert.equal(access.autofill({ context: { name: 'private'}, access: 'private'}), undefined);
+    assert.equal(access.autofill({ context: { name: '_private-name'}, access: 'auto'}), 'private');
   });
 });


### PR DESCRIPTION
* Fix #384

---

Should be merged in both `master` and `develop` once reviewed.

Tested on `sassdoc-theme-default` on my side, works as expected for the following cases:

Case | Behavior
--- | ---
explicit private without underscore | private
explicit public and underscore | public
underscore | private
nothing | public