### PR TITLE
Strip `@example` indent

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "sass-convert": "^0.5.0",
     "sassdoc-theme-default": "^2.3.4",
     "scss-comment-parser": "^0.6.0",
+    "strip-indent": "^1.0.1",
     "through2": "^0.6.3",
     "update-notifier": "^0.3.0",
     "vinyl-fs": "^1.0.0",

--- a/src/annotation/annotations/example.js
+++ b/src/annotation/annotations/example.js
@@ -7,6 +7,7 @@
  * <div></div>
  */
 
+const stripIndent = require('strip-indent');
 const descRegEx = /(\w+)\s*(?:-?\s*(.*))/;
 
 export default function example() {
@@ -33,6 +34,8 @@ export default function example() {
 
       // Remove all leading/trailing line breaks.
       instance.code = instance.code.replace(/^\n|\n$/g, '');
+
+      instance.code = stripIndent(instance.code);
 
       return instance;
     },

--- a/test/annotations/example.test.js
+++ b/test/annotations/example.test.js
@@ -15,6 +15,10 @@ describe('#example', function () {
     assert.deepEqual(example.parse('\nsome code\n'), { type: 'scss', code: 'some code' });
   });
 
+  it('should strip indent', function () {
+    assert.deepEqual(example.parse('\n    some code\n        indented\n'), { type: 'scss', code: 'some code\n    indented' });
+  });
+
   it('should extract type and description from first line', function () {
     assert.deepEqual(example.parse('type\nsome code'), { type: 'type', code: 'some code' });
     assert.deepEqual(example.parse('type - description\nsome code'), { type: 'type', description: 'description', code: 'some code' });


### PR DESCRIPTION
Fixes SassDoc/sassdoc-theme-default#76