### PR TITLE
Add a `debug` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add a `debug` option ([#407](https://github.com/SassDoc/sassdoc/pull/407))
+
 ## 2.1.13
 
 * Default destination is relative to CWD ([#403](https://github.com/SassDoc/sassdoc/pull/403))

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -62,9 +62,14 @@ export function ensureEnvironment(config, onError = e => { throw e; }) {
  * @return {Logger}
  */
 function ensureLogger(config) {
-  if (!is.object(config) || !('logger' in config)) {
+  if (!is.object(config)) {
     // Get default logger.
-    return new Logger(config && config.verbose, process.env.SASSDOC_DEBUG);
+    return new Logger();
+  }
+
+  if (!('logger' in config)) {
+    // Get default configured logger.
+    return new Logger(config.verbose, config.debug || process.env.SASSDOC_DEBUG);
   }
 
   let logger = checkLogger(config.logger);


### PR DESCRIPTION
Closes #406.

Documentation PR: SassDoc/sassdoc.github.io#119