### PR TITLE
Reword parse success message

### DIFF
--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -234,7 +234,7 @@ async function baseDocumentize(env) {
 
   filter.promise
     .then(data => {
-      env.logger.log(`Folder \`${env.src}\` successfully parsed.`);
+      env.logger.log(`Input \`${env.src}\` successfully parsed.`);
       env.data = data;
       onEmpty(data, env);
 


### PR DESCRIPTION
The input is not always a folder, it can be a file or a glob pattern too, so the message must be generic enough.

Closes #407.