### PR TITLE
Update to latest version of eslint and babel-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,11 +23,12 @@ ecmaFeatures:
 
 rules:
   no-global-strict: 0
+  no-shadow: 0
   strict: 1
   no-undef: 1
   no-use-before-define: 0
   consistent-return: 0
-  comma-dangle: "always-multiline"
+  comma-dangle: [2, "always-multiline"]
   no-process-exit: 0
 
   quotes: [2, "single"]
@@ -35,8 +36,6 @@ rules:
   no-mixed-spaces-and-tabs: [1, "smart-tabs"]
   no-spaced-func: 1
   space-after-keywords: [1, "always"]
-  space-before-function-parentheses: {"anonymous": "always", "named": "never"}
-  space-before-function-paren: {"anonymous": "always", "named": "never"}
-  space-before-blocks: "always"
-  space-in-brackets: "always"
+  space-before-function-paren: [2, {"anonymous": "always", "named": "never"}]
+  space-before-blocks: [1, "always"]
   no-underscore-dangle: 0

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "babel": "5.5.*",
-    "babel-eslint": "^2.0.2",
+    "babel-eslint": "^3.1.15",
     "coveralls": "^2.11.2",
     "dateformat": "^1.0.11",
     "eslint": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "babel-eslint": "^2.0.2",
     "coveralls": "^2.11.2",
     "dateformat": "^1.0.11",
-    "eslint": "^0.18.0",
+    "eslint": "^0.23.0",
     "istanbul": "^0.3.13",
     "jsesc": "^0.5.0",
     "jshint": "^2.6.3",

--- a/src/annotation/annotations/index.js
+++ b/src/annotation/annotations/index.js
@@ -18,5 +18,5 @@ module.exports = [
   require('./since.js'),
   require('./throw.js'),
   require('./todo.js'),
-  require('./type.js')
+  require('./type.js'),
 ];

--- a/src/annotation/annotations/name.js
+++ b/src/annotation/annotations/name.js
@@ -15,6 +15,6 @@ export default function access() {
       }
     },
 
-    multiple: false
+    multiple: false,
   };
 }

--- a/src/annotation/annotations/require.js
+++ b/src/annotation/annotations/require.js
@@ -192,7 +192,7 @@ function searchForMatches(code, regex, isAnnotatedByHandProxy, id = 1) {
   let matches = [];
 
   while ((match = regex.exec(code))) {
-    if (!isAnnotatedByHandProxy(match[id]) && (id <= 1 || match[id-1] === undefined)) {
+    if (!isAnnotatedByHandProxy(match[id]) && (id <= 1 || match[id - 1] === undefined)) {
       matches.push(match[id]);
     }
   }

--- a/src/annotation/annotations/see.js
+++ b/src/annotation/annotations/see.js
@@ -9,7 +9,7 @@ export default function see(env) {
 
       let obj = {
         type: match[1] || 'function',
-        name: match[2]
+        name: match[2],
       };
 
       if (obj.name.indexOf('$') === 0) {

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -253,7 +253,7 @@ async function baseDocumentize(env) {
     recurse(),
     exclude(env.exclude || []),
     converter({ from: 'sass', to: 'scss' }),
-    filter
+    filter,
   ];
 
   let pipeline = () => {

--- a/test/annotations/envMock.js
+++ b/test/annotations/envMock.js
@@ -3,5 +3,5 @@ module.exports = {
     warn: function () {},
     log: function () {},
     error: function () {},
-  }
+  },
 };

--- a/test/annotations/parameter.test.js
+++ b/test/annotations/parameter.test.js
@@ -35,8 +35,8 @@ describe('#parameter', function () {
         warn: function (msg) {
           assert.equal(msg, '@parameter must at least have a name. Location: FileID:1:2');
           done();
-        }
-      }
+        },
+      },
     });
     assert.deepEqual(param.parse('{type} [default] - description\nmore\nthan\none\nline', { commentRange: { start: 1, end: 2 }}, 'FileID'), undefined);
   });

--- a/test/annotations/property.test.js
+++ b/test/annotations/property.test.js
@@ -8,41 +8,41 @@ describe('#property', function () {
   it('should parse the prop annotation', function () {
     assert.deepEqual(prop.parse('base'), {
       type: 'Map',
-      name: 'base'
+      name: 'base',
     });
 
     assert.deepEqual(prop.parse('{Function} base.default'), {
       type: 'Function',
-      name: 'base.default'
+      name: 'base.default',
     });
 
     assert.deepEqual(prop.parse('{Function} base.default - description'), {
       type: 'Function',
       name: 'base.default',
-      description: 'description'
+      description: 'description',
     });
 
     assert.deepEqual(prop.parse('{Function} base.default [default] - description'), {
       type: 'Function',
       name: 'base.default',
       default: 'default',
-      description: 'description'
+      description: 'description',
     });
 
     assert.deepEqual(prop.parse('{Function} base.default [default] - description [with brackets]'), {
       type: 'Function',
       name: 'base.default',
       default: 'default',
-      description: 'description [with brackets]'
+      description: 'description [with brackets]',
     });
   });
 
-  it('should work for multiline description', function(){
+  it('should work for multiline description', function () {
     assert.deepEqual(prop.parse('{Function} base.default [default] - description\nmore\nthan\none\nline'), {
       type: 'Function',
       name: 'base.default',
       default: 'default',
-      description: 'description\nmore\nthan\none\nline'
+      description: 'description\nmore\nthan\none\nline',
     });
   });
 });

--- a/test/annotations/return.test.js
+++ b/test/annotations/return.test.js
@@ -29,8 +29,8 @@ describe('#return', function () {
         warn: function (msg) {
           assert.equal(msg, '@return must at least have a type. Location: FileID:1:2');
           done();
-        }
-      }
+        },
+      },
     });
     assert.deepEqual(ret.parse('', { commentRange: { start: 1, end: 2 }}, 'FileID'), undefined);
   });

--- a/test/api/recurse.test.js
+++ b/test/api/recurse.test.js
@@ -31,7 +31,7 @@ describe('#recurse', function () {
 describe('#recurse-null', function () {
   var files = [];
   var nullFile = new File({
-    contents: null
+    contents: null,
   });
 
   before(function (done) {

--- a/test/env/environment.test.js
+++ b/test/env/environment.test.js
@@ -107,8 +107,8 @@ describe('#environment', function () {
       display: {
         access: ['public', 'private'],
         alias: true,
-        watermark: true
-      }
+        watermark: true,
+      },
     };
 
     beforeEach(function () {

--- a/test/mock.js
+++ b/test/mock.js
@@ -32,7 +32,7 @@ Object.defineProperty(SassDocRc.prototype, 'contents', {
       throw new Error('SassDocRc.contents can only be an Object.');
     }
     this._contents = config;
-  }
+  },
 });
 
 module.exports.SassDocRc = SassDocRc;
@@ -52,7 +52,7 @@ inherits(MockLogger, Logger);
 Object.defineProperty(MockLogger.prototype, 'output', {
   get: function () {
     return this._output;
-  }
+  },
 });
 
 module.exports.Logger = MockLogger;


### PR DESCRIPTION
I just update to latest version of eslint and babel-eslint as these versions are working great in combination with SublimeLinter-contrib-eslint and sublime-babel for SublimeText 3 

We had the rule "comma-dangle" set to "always-multiline" which isn't valid in the latest version of eslint I took the liberty to correct this and fix all undetected cases. 