### PR TITLE
Update to use new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
 
 script: make travis
 
+sudo: false
+
 notifications:
   slack:
     secure: BiCHWsLTzlEd6MjRZY27BgmtCA3DmBFo5jcSsjSqmInbgla0lzDAA40xfIKTswIwK0pzuQdVaanl5Jy78wul0lfxpa5LLWX/bQmR1LGrygphC5tFG7GDM9Hdjatce5XEYVsSAUddNFEVQtMEUuUkSOiUll7kRq4LQtvAiIy1isk=


### PR DESCRIPTION
Travis has a new build infrastructure based on docker which is a lot faster we don't need sudo access so this is an easy fix.

More infos here: http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade