### PR TITLE
Fix link to JSDoc in Guidelines

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -86,7 +86,7 @@ function foo(bar = 'baz') {}
 
 ## Code blocks
 
-Whenever writing an `if`/`else` statement, the `else` keyword should directly follow the closing curly brace from the `if` statement. No line break between the closing brace and the keyword should exist. 
+Whenever writing an `if`/`else` statement, the `else` keyword should directly follow the closing curly brace from the `if` statement. No line break between the closing brace and the keyword should exist.
 
 Also, there should always be a single space between the `if` keyword and the condition.
 
@@ -104,7 +104,7 @@ Same goes with do/while and try/catch.
 
 ## Inline documentation
 
-Every function should be documented using [JSDoc](). Annotations should not be aligned in order not to have to update alignment whever a longer line is added.
+Every function should be documented using [JSDoc](http://usejsdoc.org/). Annotations should not be aligned in order not to have to update alignment whever a longer line is added.
 
 ```js
 /**
@@ -125,7 +125,7 @@ cfg.post(config);
 config.view = config; // Backward compatibility.
 
 /**
- * This is an extra long comment that does not fit on a single line because it 
+ * This is an extra long comment that does not fit on a single line because it
  * is longer than 80 characters. Because of this, it it splitted across several
  * lines.
  */


### PR DESCRIPTION
Currently, the link to JSDoc in the Guidelines documentation is missing a hyperlink.
This branch adds the missing link to http://usejsdoc.org/.

<img width="1988" alt="image on 2015-10-03 at 20-34-31" src="https://cloud.githubusercontent.com/assets/5192517/10266316/701ea9ae-6a0e-11e5-877d-97483a559677.png">
