### PR TITLE
Add CSS block in functional test.

### DIFF
--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -540,6 +540,30 @@
     }
   },
   {
+    "description": "This is a test CSS block.\n",
+    "commentRange": {
+      "start": 182,
+      "end": 183
+    },
+    "context": {
+      "type": "css",
+      "name": "data-foo",
+      "value": "color: red;",
+      "line": {
+        "start": 185,
+        "end": 186
+      }
+    },
+    "group": [
+      "test"
+    ],
+    "access": "private",
+    "file": {
+      "path": "test.scss",
+      "name": "test.scss"
+    }
+  },
+  {
     "description": "This is a global test aiming at testing:\n- `@access`\n- `@author`\n- `@deprecated`\n- `@example`\n- `@group`\n- `@ignore`\n- `@link`\n- `@requires`\n- `@see`\n- `@since`\n- `@todo`\n\n",
     "commentRange": {
       "start": 8,

--- a/test/data/test.scss
+++ b/test/data/test.scss
@@ -178,3 +178,8 @@ $variable-specific-test: ();
 /// @name placeholder-[blue,green,red]
 
 %placeholder-#{$color} {}
+
+/// This is a test CSS block.
+/// @name data-foo
+
+[data-foo="bar"] { color: red; }


### PR DESCRIPTION
This PR adds a test that fails with the version of scss-comment-parser that fails to add line context for CSS blocks, and fails with the older scss-comment-parser that doesn't understand CSS blocks at all, but passes with https://github.com/SassDoc/scss-comment-parser/pull/23

This PR should be expected to fail CI for now. Once https://github.com/SassDoc/scss-comment-parser/pull/23 is merged and a new version of scss-comment-parser is released, I will update this PR to also include an update to the newly-released scss-comment-parser, and then it will pass CI.