### PR TITLE
Hotfix/upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
-  - '0.10'
-  - '0.12'
   - '4'
-  - '5'
+  - '6'
   - 'stable'
 
 before_install:
@@ -16,7 +14,6 @@ git:
   depth: 10
 
 script: make travis
-
 
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "scss-comment-parser": "^0.8.1",
     "strip-indent": "^2.0.0",
     "through2": "^0.6.3",
-    "update-notifier": "^0.3.0",
+    "update-notifier": "^1.0.3",
     "vinyl-fs": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "js-yaml": "^3.2.1",
     "lodash.difference": "^3.1.0",
     "lodash.uniq": "^3.1.0",
-    "minimatch": "^2.0.4",
+    "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
     "multipipe": "^0.1.2",
     "rimraf": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "strip-indent": "^2.0.0",
     "through2": "^0.6.3",
     "update-notifier": "^1.0.3",
-    "vinyl-fs": "^1.0.0",
+    "vinyl-fs": "^2.4.4",
     "vinyl-source-stream": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "glob2base": "0.0.12",
     "js-yaml": "^3.2.1",
     "lodash.difference": "^4.5.0",
-    "lodash.uniq": "^3.1.0",
+    "lodash.uniq": "^4.5.0",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
     "multipipe": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lodash.uniq": "^4.5.0",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
-    "multipipe": "^0.1.2",
+    "multipipe": "^1.0.2",
     "rimraf": "^2.3.2",
     "safe-wipe": "0.*",
     "sass-convert": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "glob": "^7.1.1",
     "glob2base": "0.0.12",
     "js-yaml": "^3.2.1",
-    "lodash.difference": "^3.1.0",
+    "lodash.difference": "^4.5.0",
     "lodash.uniq": "^3.1.0",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "sass-convert": "^0.5.0",
     "sassdoc-theme-default": "^2.3.4",
     "scss-comment-parser": "^0.8.1",
-    "strip-indent": "^1.0.1",
+    "strip-indent": "^2.0.0",
     "through2": "^0.6.3",
     "update-notifier": "^0.3.0",
     "vinyl-fs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "chalk": "^1.0.0",
     "concat-stream": "^1.4.7",
     "docopt": "^0.6.1",
-    "glob": "^5.0.3",
+    "glob": "^7.1.1",
     "glob2base": "0.0.12",
     "js-yaml": "^3.2.1",
     "lodash.difference": "^3.1.0",

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -10,7 +10,9 @@ describe('#utils:denodeify', function () {
 
   it('should catch errors', function () {
     assert.doesNotThrow(function () {
-      readFile('fail');
+      readFile('fail').catch(function (err) {
+        assert.ok(utils.is.error(err));
+      });
     });
   });
 


### PR DESCRIPTION
Some dependency upgrades.

Remaning `throug2`, but the switch from streams2 to streams3 needs to be considered carefully.  
We could also pin that dependency.  