### PR TITLE
Scope empty data warning under the verbose flag

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -12,10 +12,11 @@ export default class Environment extends EventEmitter {
    * @param {Logger} logger
    * @param {Boolean} strict
    */
-  constructor (logger, strict = false) {
+  constructor (logger, verbose = false, strict = false) {
     super()
 
     this.logger = logger
+    this.verbose = verbose
     this.strict = strict
 
     this.on('error', error => {

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -337,10 +337,7 @@ function srcEnv (documentize, stream) {
 function onEmpty (data, env) {
   let message = `SassDoc could not find anything to document.\n
   * Are you still using \`/**\` comments ? They're no more supported since 2.0.
-    See <http://sassdoc.com/upgrading/#c-style-comments>.
-  * Are you documenting actual Sass items (variables, functions, mixins, placeholders) ?
-    SassDoc doesn't support documenting CSS selectors.
-    See <http://sassdoc.com/frequently-asked-questions/#does-sassdoc-support-css-classes-and-ids->.\n`
+    See <http://sassdoc.com/upgrading/#c-style-comments>.\n`
 
   if (!data.length) {
     env.emit('warning', new errors.Warning(message))

--- a/src/sassdoc.js
+++ b/src/sassdoc.js
@@ -48,7 +48,7 @@ export function ensureEnvironment (config, onError = e => { throw e }) {
   }
 
   let logger = ensureLogger(config)
-  let env = new Environment(logger, config && config.strict)
+  let env = new Environment(logger, config && config.verbose, config && config.strict)
 
   env.on('error', onError)
   env.load(config)
@@ -339,7 +339,7 @@ function onEmpty (data, env) {
   * Are you still using \`/**\` comments ? They're no more supported since 2.0.
     See <http://sassdoc.com/upgrading/#c-style-comments>.\n`
 
-  if (!data.length) {
+  if (!data.length && env.verbose) {
     env.emit('warning', new errors.Warning(message))
   }
 }


### PR DESCRIPTION
See #488 

I tried to only scope that warning, so that we don't drastically change all the other behaviours (annotation warnings etc.).

Also removed the CSS selector sentence from the warning since this is no longer true, although we don't do much promotion around it.

