### PR TITLE
Fix verbose flag and environment keys safeguard

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -36,7 +36,7 @@ export default function cli (argv = process.argv.slice(2)) {
   }
 
   let logger = new Logger(options['--verbose'], options['--debug'] || process.env.SASSDOC_DEBUG)
-  let env = new Environment(logger, options['--strict'])
+  let env = new Environment(logger, options['--verbose'], options['--strict'])
 
   logger.debug('argv:', () => JSON.stringify(argv))
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -76,15 +76,17 @@ export default class Environment extends EventEmitter {
       this.dir = path.dirname(this.file)
     }
 
-    for (let k of Object.keys(config)) {
-      if (k in this) {
-        return this.emit('error', new Error(
-          `Reserved configuration key \`${k}\`.`
-        ))
-      }
+    Object.keys(config)
+      .filter(key => ['verbose', 'strict'].indexOf(key) === -1)
+      .forEach(k => {
+        if (k in this) {
+          return this.emit('error', new Error(
+            `Reserved configuration key \`${k}\`.`
+          ))
+        }
 
-      this[k] = config[k]
-    }
+        this[k] = config[k]
+      })
   }
 
   /**

--- a/test/env/environment.test.js
+++ b/test/env/environment.test.js
@@ -20,7 +20,7 @@ describe('#environment', function () {
 
   beforeEach(function () {
     logger = new mock.Logger(true)
-    env = new Environment(logger, false)
+    env = new Environment(logger)
     warnings = logger.output
   })
 
@@ -88,12 +88,26 @@ describe('#environment', function () {
 
     beforeEach(function () {
       env.on('error', spy)
-      env.load({ fdomain: 'fail', strict: 'fail' }) // @TODO should not failt on 'strcit'
+      env.load({ logger: 'fail' })
       env.postProcess()
     })
 
     it('should error if config contains reserved keys', function () {
       assert.ok(spy.called)
+    })
+  })
+
+  describe('#config-fail', function () {
+    var spy = sinon.spy()
+
+    beforeEach(function () {
+      env.on('error', spy)
+      env.load({ verbose: true, strict: true })
+      env.postProcess()
+    })
+
+    it('should not error if config contains verbose or strict keys', function () {
+      assert.equal(spy.called, false)
     })
   })
 


### PR DESCRIPTION
Fixes #490 
Following of #489 

The same issue could be trigerred with passing `strict` as well. This MR fixes both.

