### PR TITLE
Add option to avoid filtering empty comments

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -12,6 +12,7 @@ export default class Parser {
     this.annotations = new AnnotationsApi(env)
     this.annotations.addAnnotations(additionalAnnotations)
     this.scssParser = new ScssCommentParser(this.annotations.list, env)
+    this.includeUnknownContexts = env.theme && env.theme.includeUnknownContexts
 
     this.scssParser.commentParser.on('warning', warning => {
       env.emit('warning', new errors.Warning(warning.message))
@@ -24,7 +25,7 @@ export default class Parser {
 
   /**
    * Invoke the `resolve` function of an annotation if present.
-   * Called with all found annotations except with type "unkown".
+   * Called with all found annotations except with type "unknown".
    */
   postProcess (data) {
     data = sorter(data)
@@ -91,7 +92,9 @@ export default class Parser {
     }
 
     let flush = cb => {
-      data = data.filter(item => item.context.type !== 'unknown')
+      if (!this.includeUnknownContexts) {
+        data = data.filter(item => item.context.type !== 'unknown')
+      }
       data = this.postProcess(data)
 
       deferred.resolve(data)

--- a/test/api/parser.test.js
+++ b/test/api/parser.test.js
@@ -5,6 +5,7 @@ var sinon = require('sinon')
 var mock = require('../mock')
 var Environment = require('../../dist/environment').default
 var Parser = require('../../dist/parser').default
+var source = require('vinyl-source-stream');
 
 describe('#parser', function () {
   var warnings = []
@@ -59,5 +60,19 @@ describe('#parser', function () {
 
     assert.ok(spy.called)
     assert.notEqual(-1, warnings[0].indexOf(message))
+  })
+
+  it('should include unknown contexts if requested by theme', function () {
+    parser.includeUnknownContexts = true
+    var parseStream = parser.stream()
+
+    var sourceStream = source('fake')
+    sourceStream.end('///desc\n')
+    sourceStream.pipe(parseStream)
+    return parseStream.promise.then(data => {
+      assert.equal(data.length, 1)
+      assert.equal(data[0].context.type, 'unknown')
+    })
+
   })
 })


### PR DESCRIPTION
This adds an option so that a theme can request to see all comments including the ones that are normally filtered out due to not being attached to a Sass block (see #477)