### PR TITLE
Parse group description

### DIFF
--- a/src/annotation/annotations/group.js
+++ b/src/annotation/annotations/group.js
@@ -2,8 +2,15 @@ export default function group () {
   return {
     name: 'group',
 
-    parse (text) {
-      return [text.trim().toLowerCase()]
+    parse (text, info) {
+      let lines = text.trim().split('\n')
+      let slug = lines[0].trim().toLowerCase()
+      let description = lines.splice(1).join('\n').trim()
+      if (description) {
+        info.groupDescriptions = info.groupDescriptions || {}
+        info.groupDescriptions[slug] = description
+      }
+      return [slug]
     },
 
     default () {

--- a/src/annotation/annotations/groupDescription.js
+++ b/src/annotation/annotations/groupDescription.js
@@ -1,3 +1,19 @@
+/**
+ * `@groupDescriptions` is should not be used on its own.
+ *
+ * It gets filled automatically from the lines following the `@group` annotation.
+ *
+ * @group example
+ * This is a group description. It describes the group.
+ * It can be split across multiple lines.
+ *
+ * {
+ *   'groupDescriptions': {
+ *     'example': 'This is a group description. It describes the group.\nIt can be split across multiple lines.'
+ *   }
+ * }
+ */
+
 export default function groupDescriptions () {
   return {
     name: 'groupDescriptions',

--- a/src/annotation/annotations/groupDescription.js
+++ b/src/annotation/annotations/groupDescription.js
@@ -1,0 +1,5 @@
+export default function groupDescriptions () {
+  return {
+    name: 'groupDescriptions',
+  }
+}

--- a/src/annotation/annotations/index.js
+++ b/src/annotation/annotations/index.js
@@ -6,6 +6,7 @@ module.exports = [
   require('./deprecated.js').default,
   require('./example.js').default,
   require('./group.js').default,
+  require('./groupDescription.js').default,
   require('./ignore.js').default,
   require('./link.js').default,
   require('./name.js').default,

--- a/test/annotations/api.test.js
+++ b/test/annotations/api.test.js
@@ -9,7 +9,7 @@ describe('#AnnotationsApi', function () {
   it('should include the right number of annotations', function () {
     assert.equal(
       Object.keys(api.list).length,
-      21
+      22
     )
   })
 })

--- a/test/annotations/group.test.js
+++ b/test/annotations/group.test.js
@@ -10,4 +10,12 @@ describe('#group', function () {
     assert.deepEqual(group.parse('group'), ['group'])
     assert.deepEqual(group.parse('GRoup'), ['group'])
   })
+
+  it('should parse a description from subsequent lines', function () {
+    var item = {}
+    assert.deepEqual(group.parse('group\ndescription', item), ['group'])
+    assert.deepEqual(item, {'groupDescriptions': {
+      'group': 'description'
+    }})
+  })
 })

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -2,16 +2,16 @@
   {
     "description": "This is a test function aiming at testing:\n- `@param`\n- `@return`\n- `@throw`\n\n",
     "commentRange": {
-      "start": 63,
-      "end": 73
+      "start": 65,
+      "end": 75
     },
     "context": {
       "type": "function",
       "name": "function-specific-test",
       "code": "",
       "line": {
-        "start": 75,
-        "end": 75
+        "start": 77,
+        "end": 77
       }
     },
     "parameter": [
@@ -53,8 +53,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       },
@@ -65,8 +65,8 @@
           "name": "autofill-test-handwritten",
           "code": "\n  $call: function-specific-test();\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n",
           "line": {
-            "start": 144,
-            "end": 148
+            "start": 146,
+            "end": 150
           }
         }
       },
@@ -77,8 +77,8 @@
           "name": "global-test",
           "code": "",
           "line": {
-            "start": 60,
-            "end": 60
+            "start": 62,
+            "end": 62
           }
         }
       }
@@ -87,16 +87,16 @@
   {
     "description": "This is a test mixin aiming at testing:\n- `@content`\n- `@param`\n- `@output`\n- `@throw`\n\n",
     "commentRange": {
-      "start": 79,
-      "end": 92
+      "start": 81,
+      "end": 94
     },
     "context": {
       "type": "mixin",
       "name": "mixin-specific-test",
       "code": "",
       "line": {
-        "start": 94,
-        "end": 94
+        "start": 96,
+        "end": 96
       }
     },
     "content": "Content is parsed and whatever.",
@@ -136,8 +136,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       },
@@ -148,8 +148,8 @@
           "name": "autofill-test-handwritten",
           "code": "\n  $call: function-specific-test();\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n",
           "line": {
-            "start": 144,
-            "end": 148
+            "start": 146,
+            "end": 150
           }
         }
       },
@@ -160,8 +160,8 @@
           "name": "global-test",
           "code": "",
           "line": {
-            "start": 60,
-            "end": 60
+            "start": 62,
+            "end": 62
           }
         }
       }
@@ -170,8 +170,8 @@
   {
     "description": "This is a test variable aiming at testing:\n- `@prop`\n- `@type`\n\n",
     "commentRange": {
-      "start": 98,
-      "end": 105
+      "start": 100,
+      "end": 107
     },
     "context": {
       "type": "variable",
@@ -179,8 +179,8 @@
       "value": "()",
       "scope": "private",
       "line": {
-        "start": 107,
-        "end": 107
+        "start": 109,
+        "end": 109
       }
     },
     "property": [
@@ -217,8 +217,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       },
@@ -229,8 +229,8 @@
           "name": "autofill-test-handwritten",
           "code": "\n  $call: function-specific-test();\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n",
           "line": {
-            "start": 144,
-            "end": 148
+            "start": 146,
+            "end": 150
           }
         }
       },
@@ -241,8 +241,8 @@
           "name": "global-test",
           "code": "",
           "line": {
-            "start": 60,
-            "end": 60
+            "start": 62,
+            "end": 62
           }
         }
       }
@@ -251,16 +251,16 @@
   {
     "description": "This is a test placeholder aiming at testing:\n- `@throw`\n\n",
     "commentRange": {
-      "start": 110,
-      "end": 113
+      "start": 112,
+      "end": 115
     },
     "context": {
       "type": "placeholder",
       "name": "placeholder-specific-test",
       "code": "",
       "line": {
-        "start": 115,
-        "end": 115
+        "start": 117,
+        "end": 117
       }
     },
     "throw": [
@@ -285,8 +285,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       },
@@ -297,8 +297,8 @@
           "name": "global-test",
           "code": "",
           "line": {
-            "start": 60,
-            "end": 60
+            "start": 62,
+            "end": 62
           }
         }
       }
@@ -307,16 +307,16 @@
   {
     "description": "This is a test aiming at testing:\n- autofilled `@requires`\n- autofilled `@error`\n- autofilled `@content`\n",
     "commentRange": {
-      "start": 119,
-      "end": 122
+      "start": 121,
+      "end": 124
     },
     "context": {
       "type": "mixin",
       "name": "autofill-test",
       "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
       "line": {
-        "start": 124,
-        "end": 135
+        "start": 126,
+        "end": 137
       }
     },
     "groupDescriptions": {
@@ -364,16 +364,16 @@
   {
     "description": "This is a test that autofill can be overwritten.\n",
     "commentRange": {
-      "start": 140,
-      "end": 142
+      "start": 142,
+      "end": 144
     },
     "context": {
       "type": "mixin",
       "name": "autofill-test-handwritten",
       "code": "\n  $call: function-specific-test();\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n",
       "line": {
-        "start": 144,
-        "end": 148
+        "start": 146,
+        "end": 150
       }
     },
     "require": [
@@ -407,16 +407,16 @@
   {
     "description": "This is a test that autofill should report not found\n",
     "commentRange": {
-      "start": 150,
-      "end": 151
+      "start": 152,
+      "end": 153
     },
     "context": {
       "type": "mixin",
       "name": "autofill-test-not-found",
       "code": "\n",
       "line": {
-        "start": 152,
-        "end": 153
+        "start": 154,
+        "end": 155
       }
     },
     "require": [],
@@ -435,16 +435,16 @@
   {
     "description": "This is a test function aiming at testing:\n- `@alias`\n\n",
     "commentRange": {
-      "start": 157,
-      "end": 160
+      "start": 159,
+      "end": 162
     },
     "context": {
       "type": "function",
       "name": "alias-test",
       "code": "",
       "line": {
-        "start": 162,
-        "end": 162
+        "start": 164,
+        "end": 164
       }
     },
     "alias": "alias-test-aliased",
@@ -467,8 +467,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       }
@@ -477,16 +477,16 @@
   {
     "description": "This is a test function aiming at testing:\n- `@alias`\n",
     "commentRange": {
-      "start": 164,
-      "end": 165
+      "start": 166,
+      "end": 167
     },
     "context": {
       "type": "function",
       "name": "alias-test-aliased",
       "code": "",
       "line": {
-        "start": 167,
-        "end": 167
+        "start": 169,
+        "end": 169
       }
     },
     "groupDescriptions": {
@@ -511,8 +511,8 @@
           "name": "autofill-test",
           "code": "\n  autofill-test: $autofill-test;\n  $call: function-specific-test(alias-test(),alias-test-aliased(),'test', $no);\n  $use: $variable-specific-test;\n  @include mixin-specific-test;\n  @extend %placeholder-specific-test;\n\n  @content;\n\n  @include autofill-test();\n  @error \"This is an autofilled error\";\n",
           "line": {
-            "start": 124,
-            "end": 135
+            "start": 126,
+            "end": 137
           }
         }
       }
@@ -521,16 +521,16 @@
   {
     "description": "This is a test function aiming at testing:\n- `@alias`\n\n",
     "commentRange": {
-      "start": 169,
-      "end": 172
+      "start": 171,
+      "end": 174
     },
     "context": {
       "type": "function",
       "name": "alias-test-should-warn",
       "code": "",
       "line": {
-        "start": 174,
-        "end": 174
+        "start": 176,
+        "end": 176
       }
     },
     "groupDescriptions": {
@@ -548,16 +548,16 @@
   {
     "description": "This is a test placeholder aiming at testing:\n- `@name`\n",
     "commentRange": {
-      "start": 176,
-      "end": 178
+      "start": 178,
+      "end": 180
     },
     "context": {
       "type": "placeholder",
       "name": "placeholder-[blue,green,red]",
       "code": "",
       "line": {
-        "start": 180,
-        "end": 180
+        "start": 182,
+        "end": 182
       }
     },
     "groupDescriptions": {
@@ -575,16 +575,16 @@
   {
     "description": "This is a test CSS block.\n",
     "commentRange": {
-      "start": 182,
-      "end": 183
+      "start": 184,
+      "end": 185
     },
     "context": {
       "type": "css",
       "name": "data-foo",
       "value": "color: red;",
       "line": {
-        "start": 185,
-        "end": 186
+        "start": 187,
+        "end": 188
       }
     },
     "groupDescriptions": {
@@ -602,16 +602,16 @@
   {
     "description": "This is a global test aiming at testing:\n- `@access`\n- `@author`\n- `@deprecated`\n- `@example`\n- `@group`\n- `@ignore`\n- `@link`\n- `@requires`\n- `@see`\n- `@since`\n- `@todo`\n\n",
     "commentRange": {
-      "start": 8,
-      "end": 58
+      "start": 10,
+      "end": 60
     },
     "context": {
       "type": "function",
       "name": "global-test",
       "code": "",
       "line": {
-        "start": 60,
-        "end": 60
+        "start": 62,
+        "end": 62
       }
     },
     "access": "public",
@@ -696,8 +696,8 @@
           "name": "function-specific-test",
           "code": "",
           "line": {
-            "start": 75,
-            "end": 75
+            "start": 77,
+            "end": 77
           }
         }
       }

--- a/test/data/expected.json
+++ b/test/data/expected.json
@@ -34,6 +34,9 @@
     "throw": [
       "This is an error."
     ],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -114,6 +117,9 @@
     "throw": [
       "This is an error."
     ],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -192,6 +198,9 @@
       }
     ],
     "type": "{*}",
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -257,6 +266,9 @@
     "throw": [
       "This is an error."
     ],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -306,6 +318,9 @@
         "start": 124,
         "end": 135
       }
+    },
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
     },
     "group": [
       "test"
@@ -377,6 +392,9 @@
         "external": false
       }
     ],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -402,6 +420,9 @@
       }
     },
     "require": [],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -427,6 +448,9 @@
       }
     },
     "alias": "alias-test-aliased",
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -464,6 +488,9 @@
         "start": 167,
         "end": 167
       }
+    },
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
     },
     "group": [
       "test"
@@ -506,6 +533,9 @@
         "end": 174
       }
     },
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -530,6 +560,9 @@
         "end": 180
       }
     },
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "group": [
       "test"
     ],
@@ -553,6 +586,9 @@
         "start": 185,
         "end": 186
       }
+    },
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
     },
     "group": [
       "test"
@@ -680,6 +716,9 @@
       "Nothing to do here.",
       "My people need me."
     ],
+    "groupDescriptions": {
+      "test": "This is a group description. It describes the group.\nIt can be split across multiple lines."
+    },
     "file": {
       "path": "test.scss",
       "name": "test.scss"

--- a/test/data/test.scss
+++ b/test/data/test.scss
@@ -2,6 +2,8 @@
 /// This is a top level annotation, acting for the whole file.
 /// This description is not parsed at this point but might be in the future.
 /// @group test
+/// This is a group description. It describes the group.
+/// It can be split across multiple lines.
 /// @access private
 ////
 


### PR DESCRIPTION
Fixes #520 

@pascalduez had proposed to use an object for `group` instead of adding the `groupDescriptions` key. However, I found that to many places rely on the fact that `group` is a string, so I think this is less invasive.