### PR TITLE
optimise the req regex

### DIFF
--- a/src/annotation/annotations/property.js
+++ b/src/annotation/annotations/property.js
@@ -1,4 +1,4 @@
-const reqRegEx = /\s*(?:\{(.*)\})?\s*(?:(\$?[^\s]+))?\s*(?:\[([^\]]*)\])?\s*(?:-?\s*([\s\S]*))\s*$/
+const reqRegEx = /\s*(?:{(.*)})?\s*(?:(\$?\S+))?\s*(?:\[([^\]]*)])?\s*-?\s*([\S\s]*)\s*$/
 
 export default function property () {
   return {


### PR DESCRIPTION
This was optimised by the regexp-tree-cli package like so:
```
> npx regexp-tree-cli -o -e '/\s*(?:\{(.*)\})?\s*(?:(\$?[^\s]+))?\s*(?:\[([^\]]*)\])?\s*(?:-?\s*([\s\S]*))\s*$/'
 Optimized: /\s*(?:{(.*)})?\s*(?:(\$?\S+))?\s*(?:\[([^\]]*)])?\s*-?\s*([\S\s]*)\s*$/
```