### PR TITLE
fix(annotation): fix default annotation in prop and param

### DIFF
--- a/src/annotation/annotations/parameter.js
+++ b/src/annotation/annotations/parameter.js
@@ -1,4 +1,4 @@
-const typeRegEx = /^\s*(?:\{(.*)\})?\s*(?:\$?([^\s^\]\[]+))?\s*(?:\[([^\]]*)\])?\s*(?:-?\s*([\s\S]*))?/
+const typeRegEx = /^\s*(?:\{(.*)\})?\s*(?:\$?([^\s^\]\[]+))?\s*(?:\[(.*)]\s)?\s*(?:-?\s*([\s\S]*))?/
 
 export default function parameter (env) {
   return {

--- a/src/annotation/annotations/property.js
+++ b/src/annotation/annotations/property.js
@@ -1,4 +1,4 @@
-const reqRegEx = /\s*(?:{(.*)})?\s*(?:(\$?\S+))?\s*(?:\[([^\]]*)])?\s*-?\s*([\S\s]*)\s*$/
+const reqRegEx = /\s*(?:{(.*)})?\s*(?:(\$?\S+))?\s*(?:\[(.*)]\s)?\s*-?\s*([\S\s]*)\s*$/
 
 export default function property () {
   return {

--- a/test/annotations/parameter.test.js
+++ b/test/annotations/parameter.test.js
@@ -9,6 +9,7 @@ describe('#parameter', function () {
   it('should return an object', function () {
     assert.deepEqual(param.parse('{type} $hyphenated-name [default] - description'), { type: 'type', name: 'hyphenated-name', default: 'default', description: 'description' })
     assert.deepEqual(param.parse('{type} $name [default] - description [with brackets]'), { type: 'type', name: 'name', default: 'default', description: 'description [with brackets]' })
+    assert.deepEqual(param.parse('{type} $name ["[default]"] default with inside brackets, description [with brackets]'), { type: 'type', name: 'name', default: '"[default]"', description: 'default with inside brackets, description [with brackets]' })
     assert.deepEqual(param.parse('{List} $list - list to check'), { type: 'List', name: 'list', description: 'list to check' })
   })
 

--- a/test/annotations/property.test.js
+++ b/test/annotations/property.test.js
@@ -36,6 +36,13 @@ describe('#property', function () {
       default: 'default',
       description: 'description [with brackets]'
     })
+
+    assert.deepEqual(prop.parse('{Function} base.default ["[default]"] default with inside brackets, description [with brackets]'), {
+      type: 'Function',
+      name: 'base.default',
+      default: '"[default]"',
+      description: 'default with inside brackets, description [with brackets]'
+    })
   })
 
   it('should work for multiline description', function () {


### PR DESCRIPTION
now default can include brackets inside. For example CSS attribute selector  [[attribute]] or string ["[attribute]"]

bug description:

this input
```scss
/// @param {Selector} $self-pointer ["[dir=rtl]"] - test
```
generate such output:
![image](https://user-images.githubusercontent.com/20875935/211864493-092d724f-2d99-4e36-b0b8-6117fad907a7.png)

This is regression #305